### PR TITLE
Specify encoding as UTF-8 to avoid garbled characters

### DIFF
--- a/src/main/kotlin/dev/turingcomplete/intellijbytecodeplugin/tool/_internal/InstructionsOverviewTool.kt
+++ b/src/main/kotlin/dev/turingcomplete/intellijbytecodeplugin/tool/_internal/InstructionsOverviewTool.kt
@@ -128,7 +128,7 @@ class InstructionsOverviewTool : ByteCodeTool("Instructions Overview") {
     private fun readInstructionsData(): Vector<Vector<String>> {
       val dataCsv = InstructionsOverviewTool::class.java.getResourceAsStream("/dev/turingcomplete/intellijbytecodeplugin/byte-code-instructions.csv")
         ?: throw IllegalStateException("snh: byte-code-instructions.csv missing")
-      return Vector(InputStreamReader(dataCsv).useLines { it.map { line -> Vector(line.split('|').toList()) }.toList() })
+      return Vector(InputStreamReader(dataCsv,"UTF-8").useLines { it.map { line -> Vector(line.split('|').toList()) }.toList() })
     }
   }
 }


### PR DESCRIPTION
The `byte-code-instructions.csv` file included in the plug-in is UTF-8 encoded. In some environments, the system's default encoding is GBK, which will cause incorrect reading.
Before:
![2023-12-12_154603](https://github.com/marcelkliemannel/intellij-byte-code-plugin/assets/39942874/b83acc0a-6c7f-4ccb-ad01-272d2abc40c2)
After:
![2023-12-12_154838](https://github.com/marcelkliemannel/intellij-byte-code-plugin/assets/39942874/845c46d7-f6ce-49e9-90d9-31e5190f1afe)